### PR TITLE
Bump xercesImpl from 2.11.0 to 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <annotations.version>1.5.21</annotations.version>
         <models.version>1.5.24</models.version>
         <xiaoymin.version>3.0.3</xiaoymin.version>
-        <xerces.version>2.11.0</xerces.version>
+        <xerces.version>2.12.2</xerces.version>
         <javax.version>1</javax.version>
         <whvcse.version>1.6.2</whvcse.version>
         <bitwalker.version>1.20</bitwalker.version>


### PR DESCRIPTION
Bumps xercesImpl from 2.11.0 to 2.12.2.

---
updated-dependencies:
- dependency-name: xerces:xercesImpl
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>